### PR TITLE
fixed IsForwarded()

### DIFF
--- a/message.go
+++ b/message.go
@@ -220,7 +220,7 @@ func (m *Message) LastEdited() time.Time {
 // IsForwarded says whether message is forwarded copy of another
 // message or not.
 func (m *Message) IsForwarded() bool {
-	return m.OriginalChat != nil
+	return m.OriginalSender != nil || m.OriginalChat != nil
 }
 
 // IsReply says whether message is a reply to another message.


### PR DESCRIPTION
reverts a tiny change from dbc2cd7f6, we need to check both fields because:
- m.OriginalChat is nil when message is not forwarded from a channel
- m.OriginalSender can be nil if the message is forwarded from a channel
(doc: https://core.telegram.org/bots/api#message)